### PR TITLE
argocd 프로젝트를 통한 namespace 격리

### DIFF
--- a/app/guam/guam.yaml
+++ b/app/guam/guam.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: guam
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app: api
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - image: pfcjeong/guam-gateway:latest
+          imagePullPolicy: Always
+          name: api
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 5
+          resources:
+            requests:
+              cpu: 128m
+              memory: 256Mi

--- a/argo/argocd-cm.yaml
+++ b/argo/argocd-cm.yaml
@@ -5,3 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-cm
+data:
+  accounts.snutt: login
+  accounts.guam: login
+  # argocd account update-password --account $ACCOUNT_NAME --new-password $NEW_PASSWORD --current-password $ADMIN_PASSWORD

--- a/argo/argocd-rbac-cm.yaml
+++ b/argo/argocd-rbac-cm.yaml
@@ -5,3 +5,12 @@ metadata:
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-rbac-cm
+data:
+  policy.csv: |
+    p, role:guam-admin, applications, *, guam/*, allow
+    p, role:guam-admin, clusters, get, *, allow
+    p, role:guam-admin, repositories, get, *, allow
+    p, role:guam-admin, repositories, create, *, allow
+    p, role:guam-admin, repositories, update, *, allow
+    p, role:guam-admin, repositories, delete, *, allow
+    g, guam, role:guam-admin

--- a/argo/project/guam.yaml
+++ b/argo/project/guam.yaml
@@ -11,7 +11,26 @@ spec:
     - namespace: guam
       server: https://kubernetes.default.svc
   clusterResourceWhitelist:
-    - group: '*'
-      kind: '*'
+    - group: ''
+      kind: Namespace
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
   orphanedResources:
     warn: false
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: guam
+  namespace: guam
+spec:
+  hard:
+    requests.cpu: 250m
+    limits.cpu: 250m
+    requests.memory: 512Mi
+    limits.memory: 512Mi

--- a/argo/project/guam.yaml
+++ b/argo/project/guam.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: guam
+  namespace: argocd
+spec:
+  description: Guam Project
+  sourceRepos:
+    - 'https://github.com/wafflestudio/k8s-study'
+  destinations:
+    - namespace: guam
+      server: https://kubernetes.default.svc
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  orphanedResources:
+    warn: false

--- a/argo/project/snutt.yaml
+++ b/argo/project/snutt.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: snutt
+  namespace: argocd
+spec:
+  description: Snutt Project
+  sourceRepos:
+    - 'https://github.com/wafflestudio/k8s-study'
+  destinations:
+    - namespace: snutt
+      server: https://kubernetes.default.svc
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  orphanedResources:
+    warn: false
+  roles:
+    - name: admin
+      description: Admin for snutt
+      policies:
+      - p, proj:snutt:admin, applications, *, snutt/*, allow
+      - p, proj:snutt:admin, clusters, get, *, allow
+      - p, proj:snutt:admin, repositories, get, *, allow
+      - p, proj:snutt:admin, repositories, create, *, allow
+      - p, proj:snutt:admin, repositories, update, *, allow
+      - p, proj:snutt:admin, repositories, delete, *, allow
+      groups:
+      - snutt


### PR DESCRIPTION
argocd local user에 따른 프로젝트 격리를 진행보았습니다.

먼저 snutt, guam 계정을 생성하였습니다. (비밀번호는 각각 snuttsnutt, guamguam)

guam 네임스페이스에 Service, Deployment를 배포하였고 read/write 권한을 guam 계정에만 부여하였습니다.

