### PR TITLE
github SSO 

### DIFF
--- a/argo/argocd-cm.yaml
+++ b/argo/argocd-cm.yaml
@@ -9,3 +9,15 @@ data:
   accounts.snutt: login
   accounts.guam: login
   # argocd account update-password --account $ACCOUNT_NAME --new-password $NEW_PASSWORD --current-password $ADMIN_PASSWORD
+  url: http://a42d16bf6f1c24d64a324b68cc38d470-827189050.ap-northeast-2.elb.amazonaws.com
+  dex.config: |
+    connectors:
+      # GitHub example
+      - type: github
+        id: github
+        name: GitHub
+        config:
+          clientID: 53ba1db7146e40de37f0
+          clientSecret: b28ae19011e5f30e016410bc48b4f83ced457807
+          orgs:
+          - name: pfcjeong-study

--- a/argo/argocd-rbac-cm.yaml
+++ b/argo/argocd-rbac-cm.yaml
@@ -14,3 +14,4 @@ data:
     p, role:guam-admin, repositories, update, *, allow
     p, role:guam-admin, repositories, delete, *, allow
     g, guam, role:guam-admin
+    g, pfcjeong-study:k8s, role:guam-admin


### PR DESCRIPTION
local user 별 프로젝트 격리도 가능하지만 sso를 통한 격리 역시 가능합니다.

와플 organization의 개발자 권한이 없을 것 같아서 개인 organization 만들어서 진행하였습니다.